### PR TITLE
Add highcharts library used by Charts module.

### DIFF
--- a/make/stats.make
+++ b/make/stats.make
@@ -189,4 +189,9 @@ libraries[bootstrap][download][url] = "https://github.com/twbs/bootstrap/release
 libraries[bootstrap][directory_name] = "bootstrap"
 libraries[bootstrap][type] = "library"
 
+; required by Charts module
+libraries[highcharts][download][type] = file
+libraries[highcharts][download][url] = http://code.highcharts.com/highcharts.js
+libraries[highcharts][directory_name] = "highcharts/js"
+
 

--- a/make/stats.make
+++ b/make/stats.make
@@ -190,8 +190,8 @@ libraries[bootstrap][directory_name] = "bootstrap"
 libraries[bootstrap][type] = "library"
 
 ; required by Charts module
-libraries[highcharts][download][type] = file
-libraries[highcharts][download][url] = http://code.highcharts.com/highcharts.js
+libraries[highcharts][download][type] = "file"
+libraries[highcharts][download][url] = "http://code.highcharts.com/highcharts.js"
 libraries[highcharts][directory_name] = "highcharts/js"
 
 


### PR DESCRIPTION
We're switching from Google Charts because of a bug that we're having trouble tracking down. 

Tested with successful installation of library via Makefile. 
